### PR TITLE
Add an 'open' command to open the specified error in your browser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 gem "bump", "0.3.8"
 gem "rake"
 gem "rspec", "~>2"
+gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.3.6)
     airbrake-api (4.6.0)
       faraday_middleware
       hashie
@@ -19,6 +20,8 @@ GEM
     faraday_middleware (0.9.0)
       faraday (>= 0.7.4, < 0.9)
     hashie (2.0.5)
+    launchy (2.4.2)
+      addressable (~> 2.3)
     multi_xml (0.5.5)
     multipart-post (1.2.0)
     parallel (0.9.2)
@@ -38,5 +41,6 @@ PLATFORMS
 DEPENDENCIES
   airbrake_tools!
   bump (= 0.3.8)
+  launchy
   rake
   rspec (~> 2)


### PR DESCRIPTION
Add:
- Launchy gem for cross-platform browser 'open' functionality
- New 'open' command to open the specified error (with optional notice)
  in your default browser
