### PR TITLE
add an option to change the number of pages shown

### DIFF
--- a/lib/airbrake_tools.rb
+++ b/lib/airbrake_tools.rb
@@ -6,6 +6,7 @@ require "launchy"
 module AirbrakeTools
   DEFAULT_HOT_PAGES = 1
   DEFAULT_NEW_PAGES = 1
+  DEFAULT_LIST_PAGES = 10
   DEFAULT_SUMMARY_PAGES = 10
   DEFAULT_COMPARE_DEPTH_ADDITION = 3 # first line in project is 6 -> compare at 6 + x depth
   DEFAULT_ENVIRONMENT = "production"
@@ -64,7 +65,7 @@ module AirbrakeTools
     end
 
     def list(options)
-      list_pages = options[:pages] ? options[:pages] : DEFAULT_SUMMARY_PAGES
+      list_pages = options[:pages] ? options[:pages] : DEFAULT_LIST_PAGES
       page = 1
       while errors = AirbrakeAPI.errors(page: page) and page <= list_pages
         select_env(errors, options).each do |error|


### PR DESCRIPTION
Previously there was no way to specify the number of pages returned by an API call (it would always return 10). This PR adds that option. 
